### PR TITLE
support aws profile authentication

### DIFF
--- a/src/lambda.rs
+++ b/src/lambda.rs
@@ -1,21 +1,25 @@
-use rusoto_core::{HttpClient, Region, DefaultCredentialsProvider};
+use rusoto_core::{HttpClient, Region};
 use crate::Opt;
 use rusoto_lambda::LambdaClient;
-use rusoto_core::credential::StaticProvider;
+use rusoto_core::credential::{ChainProvider, ProfileProvider, StaticProvider};
 use std::str::FromStr;
 
 pub(crate) fn create_client(opt: &Opt, region: &str) -> LambdaClient {
     let dispatcher = HttpClient::new().expect("failed to create request dispatcher");
     let region = Region::from_str(region).unwrap();
 
-    match (&opt.access_key, &opt.secret_key) {
-        (Some(access_key), Some(secret_key)) => {
+    match (&opt.access_key, &opt.secret_key, &opt.profile) {
+        (Some(access_key), Some(secret_key), _) => {
             let creds = StaticProvider::new_minimal(access_key.to_owned(), secret_key.to_owned());
             LambdaClient::new_with(dispatcher, creds, region)
-        }
+        },
+        (_, _, Some(profile)) => {
+            let mut creds = ProfileProvider::new().unwrap();
+            creds.set_profile(profile.to_owned());
+            LambdaClient::new_with(dispatcher, creds, region)
+        },
         _ => {
-            let creds =
-                DefaultCredentialsProvider::new().expect("failed to create credentials provider");
+            let creds = ChainProvider::new();
             LambdaClient::new_with(dispatcher, creds, region)
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,9 @@ mod util;
 /// Packages and deploys your project binaries to AWS Lambda
 #[derive(StructOpt, Debug)]
 struct Opt {
+    /// AWS Profile
+    #[structopt(long)]
+    profile: Option<String>,
     /// AWS Access Key
     #[structopt(long)]
     access_key: Option<String>,


### PR DESCRIPTION
this change introduces support for using profile credentials from the conventional ~/.aws/credentials file.
it is useful when more than one set of credentials exists in the credentials file.